### PR TITLE
fix-attachment-deletion-api

### DIFF
--- a/app/api/courses/[courseId]/attachments/[attachmentId]/route.ts
+++ b/app/api/courses/[courseId]/attachments/[attachmentId]/route.ts
@@ -9,6 +9,12 @@ export async function DELETE(
 ) {
     try {
         const { userId }=await auth();
+        const {courseId,attachmentId}=await params;
+
+        console.log("-----------------------------");
+        console.log(courseId);
+        console.log(attachmentId);
+
 
         if (!userId) {
             return new NextResponse("Unauthorized",{status:500})
@@ -16,7 +22,7 @@ export async function DELETE(
 
         const courseOwner = await db.course.findUnique({
             where:{
-                id:params.courseId,
+                id:courseId,
                 userId:userId
             }
         })
@@ -26,8 +32,8 @@ export async function DELETE(
 
         const attachment = await db.attachment.delete({
             where:{
-                courseId:params.courseId,
-                id:params.attachmentId,
+                courseId:courseId,
+                id:attachmentId,
             }
         });
 


### PR DESCRIPTION
1. the bug in the `attachement deletion api` was resulting  in a `404 `error
2. this was due to the structure of the folder on backend
3. the route on backend had a typo which mispelled `attachmentId `as `attachmentsId`
4. Fixing the typo resulted in the api being fixed